### PR TITLE
added transcription and charting

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -6,6 +6,8 @@ import Collection from './Collection';
 import SheetMusic from './SheetMusic';
 import Dashboard from './Dashboard';
 import Login from './Login';
+import Transcription from './Transcription';
+import Chart from './Chart';
 import { useUserContext } from './context/UserContext';
 
 const App = () => {
@@ -25,7 +27,9 @@ const App = () => {
            <Route path="/login" element={<Login />} />
            <Route path="/dashboard" element={<Dashboard />} />
            <Route path="/collection" element={<Collection />} />
-           <Route path="/sheet-music" element={<SheetMusic />} />          
+           <Route path="/sheet-music" element={<SheetMusic />} />
+           <Route path="/transcription" element={<Transcription />} /> 
+           <Route path="/chart" element={<Chart />} />             
          </Routes>   
      </BrowserRouter>
         </div>

--- a/client/src/Chart.jsx
+++ b/client/src/Chart.jsx
@@ -1,0 +1,52 @@
+import { useState, useEffect } from 'react'
+import styled from "styled-components";
+import { useUserContext } from './context/UserContext';
+import { useLocation } from 'react-router-dom';
+
+const Chart = () => {
+       
+    const { state } = useLocation();
+    const id = state.id;
+
+        console.log("id:", id);
+        useEffect(() => {
+     
+         }, []);
+
+
+  return (
+    <Wrapper>
+     
+      <div>
+      <h2>Chart!</h2>     
+    </div>
+            <MyAudio controls>
+              <source src={id} type="audio/webm" />
+            </MyAudio>
+
+        <FrameWrapper src="https://glistening-dango-ad65f2.netlify.app/"></FrameWrapper>
+
+    </Wrapper>
+  )
+}
+
+const MyAudio = styled.audio`
+    width: 100%;
+ 
+`
+const FrameWrapper = styled.iframe`
+    width: 100%;
+    height: 100vh;
+
+`
+
+const Wrapper = styled.div`
+    text-align: left;
+`
+const Line = styled.div`
+    border-bottom: 1px solid black;
+    padding-top: 20px;
+    padding-bottom: 10px;
+`
+
+export default Chart;

--- a/client/src/Collection.jsx
+++ b/client/src/Collection.jsx
@@ -4,9 +4,11 @@ import styled from "styled-components";
 import Tag from './components/Tag';
 import TagManager from './components/TagManager';
 import { useUserContext } from './context/UserContext';
+import { useNavigate } from 'react-router-dom';
 
 const Collection = () => {
 
+    const navigate = useNavigate();
     const [audioResources, setAudioResources] = useState([]);
     const [message, setMessage] = useState('');
     const [itemDeleted, setItemDeleted] = useState(false);
@@ -198,7 +200,18 @@ const handleDeleteTag = async (tagToDelete, id) => {
           setItemDeleted(true);
         }
       };
+
+      const handleTranscribe = (id) => {
+        
+        navigate('/transcription', { state: { id } });
+
+      };
       
+      const handleChart = (id) => {
+        
+        navigate('/chart', { state: { id } });
+
+      };
       
 
   // const handleDestroy = async (id) => {
@@ -305,6 +318,10 @@ const handleDeleteTag = async (tagToDelete, id) => {
             Delete audio clip
             {/* <button onClick={() => handleDestroy(resource.public_id)}>x</button>  */}
             <button onClick={() => handleDestroy('video', resource.public_id)}>x</button>
+            Transcribe this clip
+            <button onClick={() => handleTranscribe(resource.secure_url)}>Go !</button>
+            Create chart for this clip
+            <button onClick={() => handleChart(resource.secure_url)}>Go !</button>
          
           </MyListItem>
         ))}

--- a/client/src/Dashboard.jsx
+++ b/client/src/Dashboard.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { useUserContext } from './context/UserContext';
 import { styled } from 'styled-components';
+import { Link } from 'react-router-dom';
 
 const Dashboard = () => {
 
@@ -158,8 +159,8 @@ const filteredImageResources = imageResources.length > 0
     Dashboard!
     </h2>
     Current project: {selectedProject}
-    <p>Current audio clips {audioResources.length}</p> 
-    <p>Sheet music collection {imageResources.length}</p>
+    <p><Link to="/collection">Current audio clips {audioResources.length}</Link></p> 
+    <p><Link to="/sheet-music">Sheet music collection {imageResources.length}</Link></p>
     <p>Artwork</p>
     <div>
       <h2>Tag Cloud</h2>

--- a/client/src/HomePage.jsx
+++ b/client/src/HomePage.jsx
@@ -79,7 +79,7 @@ const HomePage = () => {
         onChange={handleTagsChange}
         placeholder="Enter tags separated by commas"></textarea>
         <p>This is {loggedInUser} by the way.</p>
-        <p>Working on project {selectedProject}.</p>
+        <p>Working on {selectedProject}.</p>
     </>
   )
 }

--- a/client/src/Transcription.jsx
+++ b/client/src/Transcription.jsx
@@ -1,0 +1,52 @@
+import { useState, useEffect } from 'react'
+import styled from "styled-components";
+import { useUserContext } from './context/UserContext';
+import { useLocation } from 'react-router-dom';
+
+const Transcription = () => {
+       
+    const { state } = useLocation();
+    const id = state.id;
+
+        console.log("id:", id);
+        useEffect(() => {
+     
+         }, []);
+
+
+  return (
+    <Wrapper>
+     
+      <div>
+      <h2>Transcription!</h2>     
+    </div>
+            <MyAudio controls>
+              <source src={id} type="audio/webm" />
+            </MyAudio   >
+
+        <FrameWrapper src="https://deft-hamster-0ad592.netlify.app/"></FrameWrapper>
+
+    </Wrapper>
+  )
+}
+
+const FrameWrapper = styled.iframe`
+    width: 100%;
+    height: 100vh;
+
+`
+const MyAudio = styled.audio`
+    width: 100%;
+     padding-bottom:10px;
+`
+
+const Wrapper = styled.div`
+    text-align: left;
+`
+const Line = styled.div`
+    border-bottom: 1px solid black;
+    padding-top: 20px;
+    padding-bottom: 10px;
+`
+
+export default Transcription;


### PR DESCRIPTION
Deployed two tools I'd previously created in vanilla JS / jQuery: custom music transcription and charting tools.
Made two new pages here, /transcription and /chart which contain an audio clip at the top & the tools below.
I deployed my legacy tools on Netlify and am displaying them here via iframes.
This fulfills a stretch goal I'd hoped to reach with this project: to be able to have the audio clip I'm transcribing & the transcription tools on the same page.  Currently both pages are accessed via the audio collection page via buttons, "transcribe this clip" and "create chart for this clip".